### PR TITLE
Update link to the Github First Week tutorial

### DIFF
--- a/ProgrammingAndBuildAWebsite/8-BuildaWebsitewithHTMLCSSandJavascript.md
+++ b/ProgrammingAndBuildAWebsite/8-BuildaWebsitewithHTMLCSSandJavascript.md
@@ -1,7 +1,7 @@
 # Build a Website with HTML CSS and Javascript
 Now, learn how to make a website with the Github First Week tutorials.
 
-<https://lab.github.com/githubtraining/first-week-on-github>
+[https://lab.github.com/githubtraining/first-week-on-github](https://github.com/githubtraining/first-week-on-github)
 
 Feel free to make it as complicated or basic as you would like, and have fun playing around with it. 
    

--- a/ProgrammingAndBuildAWebsite/8-BuildaWebsitewithHTMLCSSandJavascript.md
+++ b/ProgrammingAndBuildAWebsite/8-BuildaWebsitewithHTMLCSSandJavascript.md
@@ -1,7 +1,7 @@
 # Build a Website with HTML CSS and Javascript
 Now, learn how to make a website with the Github First Week tutorials.
 
-[https://lab.github.com/githubtraining/first-week-on-github](https://github.com/githubtraining/first-week-on-github)
+[https://github.com/githubtraining/first-week-on-github](https://github.com/githubtraining/first-week-on-github)
 
 Feel free to make it as complicated or basic as you would like, and have fun playing around with it. 
    


### PR DESCRIPTION
I don't know if it's been abandoned, but the original First Week on Github lab isn't up anymore. The production build of the lab on their repo (https://github.com/githubtraining/first-week-on-github) seems to be failing and it hasn't been updated in over 2 years.

I think the new Github Skills (https://skills.github.com) set of repos might be an appropriate redirection in particular the github-pages repo (https://github.com/skills/github-pages), but the content probably won't match up one-to-one.